### PR TITLE
Fix compatible table in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ movement to the next crate version in the same table row will still compile, but
 may introduce new warnings).
 
 | LLVM version | 36 | 37 | 38 | 39 |
-| ------------ | -- | -- | -- | -- |
+|--------------|----|----|----|----|
 | <3.6         |    |    |    |    |
 | 3.6.x        | ●  |    |    |    |
 | 3.7.0        |    |    |    |    |


### PR DESCRIPTION
Hi,

I noticed that a table version compatibility in README was broken on GitHub and have fixed.