### PR TITLE
Fix extern name for `LLVMHasPersonalityFn`

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -490,7 +490,7 @@ extern "C" {
     // ..->Function Values
     pub fn LLVMDeleteFunction(Fn: LLVMValueRef);
     /// Check whether the given function has a personality function.
-    pub fn LLVMHasPersonalityFunction(Fn: LLVMValueRef) -> LLVMBool;
+    pub fn LLVMHasPersonalityFn(Fn: LLVMValueRef) -> LLVMBool;
     /// Obtain the personality function attached to the function.
     ///
     /// Added in LLVM 3.7.


### PR DESCRIPTION
Fix the name of `LLVMHasPersonalityFunction` to be `LLVMHasPersonalityFn`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tari/llvm-sys.rs/7)
<!-- Reviewable:end -->
