### PR TITLE
remove LLVMAddLateCFGSimplificationPass for LLVM 6.0

### DIFF
--- a/src/transforms/scalar.rs
+++ b/src/transforms/scalar.rs
@@ -8,7 +8,8 @@ extern "C" {
     pub fn LLVMAddBitTrackingDCEPass(PM: LLVMPassManagerRef);
     pub fn LLVMAddAlignmentFromAssumptionsPass(PM: LLVMPassManagerRef);
     pub fn LLVMAddCFGSimplificationPass(PM: LLVMPassManagerRef);
-    pub fn LLVMAddLateCFGSimplificationPass(PM: LLVMPassManagerRef);
+    // Removed in LLVM 6.0.
+    // pub fn LLVMAddLateCFGSimplificationPass(PM: LLVMPassManagerRef);
     pub fn LLVMAddDeadStoreEliminationPass(PM: LLVMPassManagerRef);
     pub fn LLVMAddScalarizerPass(PM: LLVMPassManagerRef);
     pub fn LLVMAddMergedLoadStoreMotionPass(PM: LLVMPassManagerRef);


### PR DESCRIPTION
seems the `LLVMAddLateCFGSimplificationPass` has been [removed in LLVM 6.0](https://reviews.llvm.org/D38631)