### PR TITLE
Nullable-callback

### DIFF
--- a/src/disassembler.rs
+++ b/src/disassembler.rs
@@ -5,13 +5,13 @@
 pub enum LLVMOpaqueDisasmContext {}
 pub type LLVMDisasmContextRef = *mut LLVMOpaqueDisasmContext;
 
-pub type LLVMOpInfoCallback = extern "C" fn(DisInfo: *mut ::libc::c_void,
-                                            PC: u64,
-                                            Offset: u64,
-                                            Size: u64,
-                                            TagType: ::libc::c_int,
-                                            TagBuf: *mut ::libc::c_void)
-                                            -> ::libc::c_int;
+pub type LLVMOpInfoCallback = Option<extern "C" fn(DisInfo: *mut ::libc::c_void,
+                                                   PC: u64,
+                                                   Offset: u64,
+                                                   Size: u64,
+                                                   TagType: ::libc::c_int,
+                                                   TagBuf: *mut ::libc::c_void)
+                                                   -> ::libc::c_int>;
 
 #[repr(C)]
 pub struct LLVMOpInfoSymbol1 {
@@ -91,12 +91,12 @@ pub const LLVMDisassembler_Option_SetInstrComments: u64 = 8;
 /// The option to print latency information alongside instructions
 pub const LLVMDisassembler_Option_PrintLatency: u64 = 16;
 
-pub type LLVMSymbolLookupCallback = extern "C" fn(DisInfo: *mut ::libc::c_void,
-                                                  ReferenceValue: u64,
-                                                  ReferenceType: *mut u64,
-                                                  ReferencePC: u64,
-                                                  ReferenceName: *mut *const ::libc::c_char)
-                                                  -> *const ::libc::c_char;
+pub type LLVMSymbolLookupCallback = Option<extern "C" fn(DisInfo: *mut ::libc::c_void,
+                                                         ReferenceValue: u64,
+                                                         ReferenceType: *mut u64,
+                                                         ReferencePC: u64,
+                                                         ReferenceName: *mut *const ::libc::c_char)
+                                                         -> *const ::libc::c_char>;
 
 extern "C" {
     pub fn LLVMCreateDisasm(TripleName: *const ::libc::c_char,

--- a/src/error_handling.rs
+++ b/src/error_handling.rs
@@ -1,4 +1,4 @@
-pub type LLVMFatalErrorHandler = extern "C" fn(Reason: *const ::libc::c_char);
+pub type LLVMFatalErrorHandler = Option<extern "C" fn(Reason: *const ::libc::c_char)>;
 
 extern "C" {
     /// Install a fatal error handler.

--- a/src/execution_engine.rs
+++ b/src/execution_engine.rs
@@ -42,7 +42,7 @@ pub type LLVMMemoryManagerFinalizeMemoryCallback =
     extern "C" fn(Opaque: *mut ::libc::c_void,
                   ErrMsg: *mut *mut ::libc::c_char)
                   -> LLVMBool;
-pub type LLVMMemoryManagerDestroyCallback = extern "C" fn(Opaque: *mut ::libc::c_void);
+pub type LLVMMemoryManagerDestroyCallback = Option<extern "C" fn(Opaque: *mut ::libc::c_void)>;
 
 extern "C" {
     pub fn LLVMLinkInMCJIT();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,6 +344,6 @@ pub const LLVMAttributeFunctionIndex: ::libc::c_uint = !0; // -1
 /// number from 1 to N.
 pub type LLVMAttributeIndex = ::libc::c_uint;
 
-pub type LLVMDiagnosticHandler = extern "C" fn(arg1: LLVMDiagnosticInfoRef,
-                                               arg2: *mut ::libc::c_void);
-pub type LLVMYieldCallback = extern "C" fn(arg1: LLVMContextRef, arg2: *mut ::libc::c_void);
+pub type LLVMDiagnosticHandler = Option<extern "C" fn(arg1: LLVMDiagnosticInfoRef,
+                                                      arg2: *mut ::libc::c_void)>;
+pub type LLVMYieldCallback = Option<extern "C" fn(arg1: LLVMContextRef, arg2: *mut ::libc::c_void)>;

--- a/src/lto.rs
+++ b/src/lto.rs
@@ -71,9 +71,9 @@ pub enum lto_codegen_diagnostic_severity_t {
     LTO_DS_NOTE = 2,
 }
 
-pub type lto_diagnostic_handler_t = extern "C" fn(severity: lto_codegen_diagnostic_severity_t,
-                                                  diag: *const ::libc::c_char,
-                                                  ctxt: *mut ::libc::c_void);
+pub type lto_diagnostic_handler_t = Option<extern "C" fn(severity: lto_codegen_diagnostic_severity_t,
+                                                         diag: *const ::libc::c_char,
+                                                         ctxt: *mut ::libc::c_void)>;
 
 extern "C" {
     pub fn lto_get_version() -> *const ::libc::c_char;

--- a/src/orc.rs
+++ b/src/orc.rs
@@ -10,8 +10,8 @@ pub type LLVMOrcJITStackRef = *mut LLVMOrcOpaqueJITStack;
 pub type LLVMOrcModuleHandle = u32;
 pub type LLVMOrcTargetAddress = u64;
 
-pub type LLVMOrcSymbolResolverFn = extern "C" fn(*const ::libc::c_char, *mut ::libc::c_void) -> u64;
-pub type LLVMOrcLazyCompileCallbackFn = extern "C" fn(LLVMOrcJITStackRef, *mut ::libc::c_void);
+pub type LLVMOrcSymbolResolverFn = Option<extern "C" fn(*const ::libc::c_char, *mut ::libc::c_void) -> u64>;
+pub type LLVMOrcLazyCompileCallbackFn = Option<extern "C" fn(LLVMOrcJITStackRef, *mut ::libc::c_void)>;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum LLVMOrcErrorCode {


### PR DESCRIPTION
As discussed in [The "nullable pointer optimization"](https://doc.rust-lang.org/book/first-edition/ffi.html#the-nullable-pointer-optimization) section of the Rust book, the type of function pointers for C FFI should be `Option<extern fn(...)>`.