### PR TITLE
Feature to disable actual linking against LLVM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ appveyor = { service = "bitbucket", repository = "tari/llvm-sys.rs", branch = "d
 
 [features]
 strict-versioning = []
+no-llvm-linking = []
 
 [dependencies]
 libc = "0.2"

--- a/build.rs
+++ b/build.rs
@@ -53,10 +53,10 @@ lazy_static!{
 
         println!("No suitable version of LLVM was found system-wide or pointed
                   to by {}.
-                  
+
                   Consider using `llvmenv` to compile an appropriate copy of LLVM, and
                   refer to the llvm-sys documentation for more information.
-                  
+
                   llvm-sys: https://crates.io/crates/llvm-sys
                   llvmenv: https://crates.io/crates/llvmenv", binary_prefix_var);
         panic!("Could not find a compatible version of LLVM");
@@ -278,6 +278,10 @@ fn get_llvm_cflags() -> String {
 }
 
 fn main() {
+    if cfg!(feature = "no-llvm-linking") {
+        return;
+    }
+
     let libdir = llvm_config("--libdir");
 
     // Export information to other crates


### PR DESCRIPTION
The feature is optional, and simply disables `build.rs` code in the crate.

It can be useful when the main binary has own `build.rs` logic responsible for linking.
Another case can be dynamic dispatch implemented in [rustc-llvm-proxy](https://github.com/denzp/rustc-llvm-proxy).