### PR TITLE
Add MUSL support to the build script

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -339,6 +339,9 @@ fn get_system_libcpp() -> Option<&'static str> {
         Some("c++")
     } else if target_os_is("freebsd") {
         Some("c++")
+    } else if target_env_is("musl") {
+        // The one built with musl.
+        Some("c++")
     } else {
         // Otherwise assume GCC's libstdc++.
         // This assumption is probably wrong on some platforms, but would need
@@ -456,7 +459,8 @@ fn main() {
 
     // Link system libraries
     for name in get_system_libraries() {
-        println!("cargo:rustc-link-lib=dylib={}", name);
+        let link_type = if target_env_is("musl") { "static" } else { "dylib" };
+        println!("cargo:rustc-link-lib={}={}", link_type, name);
     }
 
     let use_debug_msvcrt = env::var_os(&*ENV_USE_DEBUG_MSVCRT).is_some();


### PR DESCRIPTION
Add the `musl` environment branch to the libcpp and system libraries building logic.
All libraries are linked statically in this case.

We've been using this for more than 6 months, so it's completely tested.

Feel free to rebase it onto all branches you think are appropriate.