### PR TITLE
Check if the LLVM build directory contents has been changed

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -411,6 +411,10 @@ fn is_llvm_debug() -> bool {
 fn main() {
     // Behavior can be significantly affected by these vars.
     println!("cargo:rerun-if-env-changed={}", &*ENV_LLVM_PREFIX);
+    if let Ok(path) = env::var(&*ENV_LLVM_PREFIX) {
+        println!("cargo:rerun-if-changed={}", path);
+    }
+
     println!("cargo:rerun-if-env-changed={}", &*ENV_IGNORE_BLOCKLIST);
     println!("cargo:rerun-if-env-changed={}", &*ENV_STRICT_VERSIONING);
     println!("cargo:rerun-if-env-changed={}", &*ENV_NO_CLEAN_CFLAGS);


### PR DESCRIPTION
Checks not only if the `LLVM_version_SYS` variable was changed, but also the contents of the directory it points to.
Thus you may re-build your LLVM framework when you've made some changes, and `cargo` will automatically re-run `build.rs` to catch up with your changes. Otherwise the changes are not tracked and you have to remove the `llvm-sys` library binaries from the `target` directory manually.

We've been using this for more than 6 months, so it's completely tested.

Feel free to rebase it onto all branches you think are appropriate.