### PR TITLE
Add functions for parsing text LLVM IR

### DIFF
--- a/src/bit_reader.rs
+++ b/src/bit_reader.rs
@@ -21,6 +21,24 @@ extern "C" {
         OutModule: *mut LLVMModuleRef,
     ) -> LLVMBool;
 
+    /// Build a module from the IR in the specified memory buffer.
+    ///
+    /// Returns 0 on success and the generated module in `OutModule`.
+    /// Optionally returns a human-readable error message in `OutMessage`.
+    #[deprecated(since = "3.8", note = "Use LLVMParseIR2")]
+    pub fn LLVMParseIR(
+        MemBuf: LLVMMemoryBufferRef,
+        OutModule: *mut LLVMModuleRef,
+        OutMessage: *mut *mut ::libc::c_char,
+    ) -> LLVMBool;
+    /// Build a module from the IR in the specified memory buffer.
+    ///
+    /// Returns the created module in OutModule, returns 0 on success.
+    pub fn LLVMParseIR2(
+        MemBuf: LLVMMemoryBufferRef,
+        OutModule: *mut LLVMModuleRef,
+    ) -> LLVMBool;
+
     #[deprecated(since = "3.8", note = "Use LLVMParseBitcodeInContext2")]
     pub fn LLVMParseBitcodeInContext(
         ContextRef: LLVMContextRef,
@@ -29,6 +47,19 @@ extern "C" {
         OutMessage: *mut *mut ::libc::c_char,
     ) -> LLVMBool;
     pub fn LLVMParseBitcodeInContext2(
+        ContextRef: LLVMContextRef,
+        MemBuf: LLVMMemoryBufferRef,
+        OutModule: *mut LLVMModuleRef,
+    ) -> LLVMBool;
+
+    #[deprecated(since = "3.8", note = "Use LLVMParseIRInContext2")]
+    pub fn LLVMParseIRInContext(
+        ContextRef: LLVMContextRef,
+        MemBuf: LLVMMemoryBufferRef,
+        OutModule: *mut LLVMModuleRef,
+        OutMessage: *mut *mut ::libc::c_char,
+    ) -> LLVMBool;
+    pub fn LLVMParseIRInContext2(
         ContextRef: LLVMContextRef,
         MemBuf: LLVMMemoryBufferRef,
         OutModule: *mut LLVMModuleRef,


### PR DESCRIPTION
Adds bindings for functions that parse text LLVM IR (`*.ll` files). Before that only binary bitcode files could be parsed into module.

We've been using this for more than 6 months, so it's completely tested.

Feel free to rebase it onto all branches you think are appropriate.